### PR TITLE
feat: parameterize base URL in ZeptoMail client for region flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import (
 
 func main() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	data := "<div><b> Kindly click on Verify Account to confirm your account </b></div>"
 	req := zeptomail.SendHTMLEmailReq{
@@ -239,7 +239,7 @@ import (
 func main() {
 	zeptomailToken := "your zeptomail authorization token"
 	tempKey := "your zeptomail template key"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	req := zeptomail.SendTemplatedEmailReq{
 		To: []zeptomail.SendEmailTo{

--- a/examples/main.go
+++ b/examples/main.go
@@ -46,7 +46,7 @@ func main() {
 // sendHTMLEmail sends a HTML Email
 func sendHTMLEmail() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	data := "<div><b> Kindly click on Verify Account to confirm your account </b></div>"
 	req := zeptomail.SendHTMLEmailReq{
@@ -80,7 +80,7 @@ func sendTemplatedEmail() {
 	zeptomailToken := "your zeptomail authorization token"
 	tempKey := "your template key"
 
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 	req := zeptomail.SendTemplatedEmailReq{
 		To: []zeptomail.SendEmailTo{
 			{
@@ -116,7 +116,7 @@ func SendBatchTemplatedEmail() {
 	zeptomailToken := "your zeptomail authorization token"
 	tempKey := "your zeptomail template key"
 
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 	req := zeptomail.SendBatchTemplatedEmailReq{
 		To: []zeptomail.SendBatchTemplateEmailTo{
 			{
@@ -149,7 +149,7 @@ func SendBatchTemplatedEmail() {
 // AddEmailTemplate can be used to add an email template.
 func AddEmailTemplate() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	req := zeptomail.AddEmailTemplateReq{
 		TemplateName:   "E-invite",
@@ -170,7 +170,7 @@ func AddEmailTemplate() {
 // UpdateEmailTemplate can be used to update an email template.
 func UpdateEmailTemplate() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	req := zeptomail.UpdateEmailTemplateReq{
 		TemplateName:   "E-invite",
@@ -193,7 +193,7 @@ func GetEmailTemplate() {
 	zeptomailToken := "your zeptomail authorization token"
 	var TemplateKey, MailagentAlias string = "your template key", "mail agent alias"
 
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 	res, err := client.GetEmailTemplate(MailagentAlias, TemplateKey)
 	if err != nil {
 		fmt.Printf("This is the error: %v", err.Error())
@@ -206,7 +206,7 @@ func GetEmailTemplate() {
 func DeleteEmailTemplate() {
 	zeptomailToken := "your zeptomail authorization token"
 	var TemplateKey, MailagentAlias string = "your template key", "mail agent alias"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	res, err := client.DeleteEmailTemplate(MailagentAlias, TemplateKey)
 	if err != nil {
@@ -218,7 +218,7 @@ func DeleteEmailTemplate() {
 
 func SendBatchHTMLEmail() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	data := "<div><b>This is a sample email.{{contact}} {{company}}</b></div"
 	req := zeptomail.SendBatchHTMLEmailReq{
@@ -256,7 +256,7 @@ func SendBatchHTMLEmail() {
 // filecacheupload is used to upload file to file cache
 func FileCacheUploadAPI() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	// Set the file path
 	filePath := "path_to_your_file.jpg"
@@ -294,7 +294,7 @@ func FileCacheUploadAPI() {
 
 func ListEmailTemplates() {
 	zeptomailToken := "your zeptomail authorization token"
-	client := zeptomail.New(*http.DefaultClient, zeptomailToken)
+	client := zeptomail.New(*http.DefaultClient, zeptomailToken, "")
 
 	var Offset, Limit int
 	var MailagentAlias string

--- a/zeptomail.go
+++ b/zeptomail.go
@@ -22,9 +22,12 @@ type Client struct {
 }
 
 // New is the zeptomail config initializer
-func New(h http.Client, token string) *Client {
+func New(h http.Client, token, baseUrl string) *Client {
+	if baseUrl == "" {
+		baseUrl = "https://api.zeptomail.com/v1.1/"
+	}
 	return &Client{
-		BaseUrl: "https://api.zeptomail.com/v1.1/",
+		BaseUrl: baseUrl,
 		Http:    &h,
 		Token:   token,
 	}


### PR DESCRIPTION
- Added BaseUrl field to Client struct
- Updated constructor to accept a custom base URL with default fallback
- Replaced all hardcoded API base URLs with the parameterized BaseUrl
- Enables support for different regional endpoints (.com, .in, etc.) without code changes